### PR TITLE
security - Fix two brakeman warnings

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -1,6 +1,6 @@
 module Api
   class BaseController < ActionController::Base
-    skip_before_action :verify_authenticity_token
+    protect_from_forgery with: :null_session
 
     private
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,5 @@
 class ApplicationController < ActionController::Base
-  protect_from_forgery
+  protect_from_forgery with: :exception
 
   helper_method :current_user
 


### PR DESCRIPTION
The first is a medium severity warning regarding `ApplicationController`
where `protect_from_forgery` has been used without any option, in this
case the default value is to nullify the session, but this is not the
most secure way to handle CSRF attacks, see
http://brakemanscanner.org/docs/warning_types/cross-site_request_forgery/.

The second is a high severity warning regarding `Api::BaseController`.
For all API controllers, that are controllers that derive from
`Api::BaseController`, CSRF is disabled. Even if this behavior should be
safe because we're not using session data in these controllers, brakeman
complains about the missing `protect_from_forgery` protection. Let's
enable the `null_session` behavior that will prevent CSRF attacks, but
won't raise any exception in case of missing authenticity tokens.