### PR TITLE
NEW: Handle ActionController::ParameterMissing for API requests

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -3,7 +3,7 @@ module Api
     protect_from_forgery with: :null_session
 
     rescue_from(ActionController::ParameterMissing) do |err|
-      render json: {missing_param: err.param}, status: :bad_request
+      render json: { missing_param: err.param }, status: :bad_request
     end
 
     private

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -2,6 +2,10 @@ module Api
   class BaseController < ActionController::Base
     protect_from_forgery with: :null_session
 
+    rescue_from(ActionController::ParameterMissing) do |err|
+      render json: {missing_param: err.param}, status: :bad_request
+    end
+
     private
 
     def current_user

--- a/test/functional/api/tomatoes_controller_test.rb
+++ b/test/functional/api/tomatoes_controller_test.rb
@@ -91,6 +91,20 @@ module Api
       assert_match(/Must not overlap saved tomaotes/, parsed_response['base'].first)
     end
 
+    test 'POST /create, with bad parameters, it should return a bad request error' do
+      @user.tomatoes.create!
+
+      assert_no_difference('@user.tomatoes.size') do
+        # this request should fail because another tomato has been created
+        # less than 25 minutes ago
+        post :create, token: '123', pachino: { tag_list: 'one, two' }
+      end
+      assert_response :bad_request
+      assert_equal 'application/json', @response.content_type
+      parsed_response = JSON.parse(@response.body)
+      assert_match('tomato', parsed_response['missing_param'])
+    end
+
     test 'PATCH /update, given an invalid token, it should return an error' do
       patch :update, token: 'invalid_token', id: @tomato_1.id, tomato: { tag_list: 'three' }
       assert_response :unauthorized

--- a/test/functional/api/tomatoes_controller_test.rb
+++ b/test/functional/api/tomatoes_controller_test.rb
@@ -95,8 +95,8 @@ module Api
       @user.tomatoes.create!
 
       assert_no_difference('@user.tomatoes.size') do
-        # this request should fail because another tomato has been created
-        # less than 25 minutes ago
+        # this request should fail because no tomato param
+        # has been given
         post :create, token: '123', pachino: { tag_list: 'one, two' }
       end
       assert_response :bad_request


### PR DESCRIPTION
Handle ActionController::ParameterMissing error for API requests and
return a bad request status with info about the missing parameter.

Related to issue #195.