### PR TITLE
Remind if pomodoro has not been saved or started

### DIFF
--- a/app/assets/javascripts/TT.js
+++ b/app/assets/javascripts/TT.js
@@ -6,6 +6,7 @@
 //
 //= require notifier
 //= require TT_init
+//= require TT_reminder
 
 var TT = function() {
   var timerInterval = null,

--- a/app/assets/javascripts/TT_reminder.js
+++ b/app/assets/javascripts/TT_reminder.js
@@ -1,0 +1,45 @@
+var TTReminder = function() {
+  var reminderId,         // reminder timeout callback id
+      maxBackoffExp = 4,  // max exponential backoff
+      constantDelay = 10, // constant delay in seconds
+      baseDelay = 6;      // base delay in seconds
+
+  var delayReminderExp = function (exp, message) {
+    reminderId = setTimeout(function() {
+      // reminder notification
+      if (!NOTIFIER.notify(tomatoNotificationIcon, "Tomatoes", message)) {
+        log('Permission denied. Click "Request Permission" to give this domain access to send notifications to your desktop.');
+      }
+
+      // conditionally delay the next reminder
+      if (exp + 1 <= maxBackoffExp) {
+        delayReminderExp(exp + 1, message);
+      }
+    }, delay(exp));
+  };
+
+  var delay = function(exp) {
+    return (Math.pow(baseDelay, exp) + constantDelay) * 1000;
+  };
+
+  var resetReminder = function() {
+    clearTimeout(reminderId);
+  };
+
+  return {
+    resetReminder: resetReminder,
+    delayReminder: delayReminderExp.bind(this, 1)
+  };
+}();
+
+// initialize TTReminder
+$(document).ready(function() {
+  $(document).on('timer_start', TTReminder.resetReminder);
+  $(document).on('timer_stop', function() {
+    TTReminder.resetReminder();
+    TTReminder.delayReminder('Did you forget to start your next tomato?');
+  });
+  $(document).on('new_tomato_form', function() {
+    TTReminder.delayReminder('Did you forget to save your current tomato?');
+  });
+});


### PR DESCRIPTION
`TTReminder` hooks on three timer events: `timer_start`, `timer_stop`,
`new_tomato_form`. It reminds the user if the current tomato has not
been saved or if a new one could be started after a break.

The script will start notifying the user after 10 + 6^1 seconds. It will
send a second notification after 10 + 6^2 seconds from the first one. It
stops after the fourth notification, that should arrive after 10 + 6^4
seconds from the previous notification.

Reminder notifications times:

1. 10 + 6^1 = 16 seconds after the event
2. 10 + 6^2 = 46 seconds after the 1st notification
3. 10 + 6^3 = 3 minutes, 46 seconds after the 2nd notification
4. 10 + 6^4 = 21 minutes, 46 seconds after the 3rd notification

This is the first approach that I though to fix #109.

An alternative approach would be to notify the user only once, but to
make the notification last longer. This would prevent the case when the
user just doesn't want to start a new tomato, but he/she will keep
receiving notifications.

I didn't implement a sound notification, as suggested by #93, because
I think it would be too *noisy*.