### PR TITLE
Remind if pomodoro has not been saved or started (alternative implementation)

### DIFF
--- a/app/assets/javascripts/TT.js
+++ b/app/assets/javascripts/TT.js
@@ -115,7 +115,7 @@ var TT = function() {
     $("#" + settings.progressBarId).css('width', 0);
 
     if(typeof reset == 'undefined') {
-      if (!NOTIFIER.notify(tomatoNotificationIcon, "Tomatoes", "Break is over. It's time to work.")) {
+      if (!NOTIFIER.notify(tomatoNotificationIcon, "Tomatoes", "Break is over. It's time to work.", false)) {
         log('Permission denied. Click "Request Permission" to give this domain access to send notifications to your desktop.');
       }
     }
@@ -133,7 +133,7 @@ var TT = function() {
     document.title = originalTitle;
 
     // notify tomato end
-    if (!NOTIFIER.notify(tomatoNotificationIcon, "Tomatoes", "Pomodoro finished!")) {
+    if (!NOTIFIER.notify(tomatoNotificationIcon, "Tomatoes", "Pomodoro finished!", false)) {
       log('Permission denied. Click "Request Permission" to give this domain access to send notifications to your desktop.');
     }
 
@@ -150,7 +150,7 @@ var TT = function() {
     document.title = originalTitle;
 
     // notify tomato end
-    if (!NOTIFIER.notify(tomatoNotificationIcon, "Tomatoes", "Pomodoro finished!")) {
+    if (!NOTIFIER.notify(tomatoNotificationIcon, "Tomatoes", "Pomodoro finished!", false)) {
       log('Permission denied. Click "Request Permission" to give this domain access to send notifications to your desktop.');
     }
 

--- a/app/assets/javascripts/TT.js
+++ b/app/assets/javascripts/TT.js
@@ -6,6 +6,7 @@
 //
 //= require notifier
 //= require TT_init
+//= require TT_reminder
 
 var TT = function() {
   var timerInterval = null,

--- a/app/assets/javascripts/TT_reminder.js
+++ b/app/assets/javascripts/TT_reminder.js
@@ -1,0 +1,24 @@
+var TTReminder = function() {
+  var reminderDelay = 20; // constant delay in seconds
+
+  var delayReminder = function(message) {
+    setTimeout(function() {
+      // reminder notification
+      NOTIFIER.notify(tomatoNotificationIcon, 'Tomatoes', message, true);
+    }, reminderDelay * 1000);
+  };
+
+  return {
+    delayReminder: delayReminder
+  };
+}();
+
+// initialize TTReminder
+$(document).ready(function() {
+  $(document).on('timer_stop', function() {
+    TTReminder.delayReminder('Did you forget to start your next tomato?');
+  });
+  $(document).on('new_tomato_form', function() {
+    TTReminder.delayReminder('Did you forget to save your current tomato?');
+  });
+});

--- a/app/assets/javascripts/notifier.js
+++ b/app/assets/javascripts/notifier.js
@@ -21,21 +21,24 @@ Notifier.prototype.getPermission = function() {
 
 // Popup a notification with icon, title, and body. Returns false if
 // permission was not granted.
-Notifier.prototype.notify = function(icon, title, body) {
+Notifier.prototype.notify = function(icon, title, body, requireInteraction) {
   if (this.isPermissionGranted()) {
-    console.log(icon, title, body);
-
-    var notification = new Notification(body, { icon: icon, title: title });
-    console.log(notification);
+    var notification = new Notification(title, {
+      icon: icon,
+      body: body,
+      requireInteraction: requireInteraction
+    });
 
     notification.onclick = function() {
       window.focus();
       notification.close();
     };
 
-    setTimeout(function() {
-      notification.close();
-    }, 10000);
+    if (!requireInteraction) {
+      setTimeout(function() {
+        notification.close();
+      }, 10000);
+    }
 
     return true;
   }


### PR DESCRIPTION
TTReminder hooks on two timer events: `timer_stop` and `new_tomato_form`.
It reminds the user if the current tomato has not been saved or if a new
one could be started after a break.

This is an alternative implementation of
#247, that relies on the
`requireInteraction` option.

From MDN `Notification` documentation:

> Indicates that a notification should remain active until the user
> clicks or dismisses it, rather than closing automatically. The default
> value is `false`.

See
https://developer.mozilla.org/en-US/docs/Web/API/Notification/Notification

Closes #247 and #109.