### PR TITLE
Add codeclimate code coverage integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,6 @@ before_install:
 script:
   - bundle exec rake test
   - bundle exec rubocop -R
+addons:
+    code_climate:
+        repo_token: YOUR_CODECLIMATE_APP_TOKEN

--- a/Gemfile
+++ b/Gemfile
@@ -62,6 +62,7 @@ group :test do
   gem 'mocha', require: false
   gem 'minitest-reporters'
   gem 'simplecov', require: false
+  gem 'codeclimate-test-reporter', '~> 1.0.0', require: nil
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,6 +63,8 @@ GEM
     buftok (0.2.0)
     builder (3.2.3)
     byebug (9.0.6)
+    codeclimate-test-reporter (1.0.5)
+      simplecov
     coderay (1.1.1)
     concurrent-ruby (1.0.4)
     dalli (2.7.6)
@@ -308,6 +310,7 @@ DEPENDENCIES
   bootstrap-sass (~> 3.3.6)
   bootstrap-social-rails
   byebug
+  codeclimate-test-reporter (~> 1.0.0)
   dalli
   exception_notification
   fog-aws

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,5 @@
 ENV['RAILS_ENV'] = 'test'
+require 'codeclimate-test-reporter'
 require 'simplecov'
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'


### PR DESCRIPTION
Within this PR there is the missing configuration for the codeclimate code coverage feature.

@potomak to make it works we need the codeclimate **application token** (not your user token) that should be placed into the `.travis.yml` file replacing the `YOUR_CODECLIMATE_APP_TOKEN` placeholder.

Here you can find more info: https://docs.codeclimate.com/docs/setting-up-test-coverage#how-to