### PR TITLE
Fix: use assert_nil

### DIFF
--- a/test/functional/sessions_controller_test.rb
+++ b/test/functional/sessions_controller_test.rb
@@ -32,21 +32,21 @@ class SessionsControllerTest < ActionController::TestCase
 
   test 'should get destroy' do
     get :destroy
-    assert_equal nil, session[:user_id]
+    assert_nil session[:user_id]
     assert_redirected_to root_url
     assert_equal 'Signed out!', flash[:notice]
   end
 
   test 'should get failure' do
     get :failure, message: 'failure message'
-    assert_equal nil, session[:user_id]
+    assert_nil session[:user_id]
     assert_redirected_to root_url
     assert_equal "Authentication error: #{'failure message'.humanize}", flash[:alert]
   end
 
   test 'should handle failure when no message passed' do
     get :failure
-    assert_equal nil, session[:user_id]
+    assert_nil session[:user_id]
     assert_redirected_to root_url
     assert_equal 'Authentication error: Unknown', flash[:alert]
   end

--- a/test/unit/jobs/increment_score_job_test.rb
+++ b/test/unit/jobs/increment_score_job_test.rb
@@ -12,7 +12,7 @@ class IncrementScoreJobTest < ActiveSupport::TestCase
   end
 
   test 'creates a new daily score' do
-    assert_equal @user.daily_score, nil
+    assert_nil @user.daily_score
     IncrementScoreJob.new.perform(@user._id)
     @user.reload
     assert_equal @user.daily_score, DailyScore.last

--- a/test/unit/operations/increment_score_test.rb
+++ b/test/unit/operations/increment_score_test.rb
@@ -13,7 +13,7 @@ class IncrementScoreTest < ActiveSupport::TestCase
   end
 
   test 'creates a new daily score' do
-    assert_equal @user.daily_score, nil
+    assert_nil @user.daily_score
     @inc_operation.process
     @user.reload
     assert_equal @user.daily_score, DailyScore.last


### PR DESCRIPTION
Use assert_nil if expecting nil.
Using `assert_equal value, nil` will fail in MT6.