### PR TITLE
Properly use user timezone in leaderboards

### DIFF
--- a/app/models/concerns/expiring.rb
+++ b/app/models/concerns/expiring.rb
@@ -1,7 +1,7 @@
 module Expiring
   extend ActiveSupport::Concern
   included do
-    field :eat, as: :expires_at, type: DateTime
+    field :eat, as: :expires_at, type: Time
     index({ eat: 1 }, expire_after_seconds: 0, name: 'expiration_index')
   end
 end

--- a/app/operations/increment_score.rb
+++ b/app/operations/increment_score.rb
@@ -8,9 +8,9 @@ class IncrementScore
   end
 
   def process
-    upsert_score(DailyScore, now_in_user_zone.end_of_day)
-    upsert_score(WeeklyScore, now_in_user_zone.end_of_week)
-    upsert_score(MonthlyScore, now_in_user_zone.end_of_month)
+    upsert_score(DailyScore, user_time_zone.now.end_of_day)
+    upsert_score(WeeklyScore, user_time_zone.now.end_of_week)
+    upsert_score(MonthlyScore, user_time_zone.now.end_of_month)
     upsert_score(OverallScore)
   end
 
@@ -35,8 +35,7 @@ class IncrementScore
     @user ||= User.find(user_id)
   end
 
-  def now_in_user_zone
-    zone = ActiveSupport::TimeZone[user.time_zone.to_s] || Time.zone
-    zone.now
+  def user_time_zone
+    ActiveSupport::TimeZone[user.time_zone.to_s] || Time.zone
   end
 end

--- a/app/operations/increment_score.rb
+++ b/app/operations/increment_score.rb
@@ -8,10 +8,9 @@ class IncrementScore
   end
 
   def process
-    now = Time.current
-    upsert_score(DailyScore, to_user_timezone(now.end_of_day))
-    upsert_score(WeeklyScore, to_user_timezone(now.end_of_week))
-    upsert_score(MonthlyScore, to_user_timezone(now.end_of_month))
+    upsert_score(DailyScore, now_in_user_zone.end_of_day)
+    upsert_score(WeeklyScore, now_in_user_zone.end_of_week)
+    upsert_score(MonthlyScore, now_in_user_zone.end_of_month)
     upsert_score(OverallScore)
   end
 
@@ -36,7 +35,8 @@ class IncrementScore
     @user ||= User.find(user_id)
   end
 
-  def to_user_timezone(t)
-    t.in_time_zone(user.time_zone)
+  def now_in_user_zone
+    zone = ActiveSupport::TimeZone[user.time_zone.to_s] || Time.zone
+    zone.now
   end
 end

--- a/test/unit/operations/increment_score_test.rb
+++ b/test/unit/operations/increment_score_test.rb
@@ -31,4 +31,49 @@ class IncrementScoreTest < ActiveSupport::TestCase
     assert_equal @user.daily_score, score
     assert_equal DailyScore.count, 1
   end
+
+  test 'sets daily score expiration date '\
+      'to the end of the current day in America/New_York '\
+      'for a user in America/New_York' do
+    @user.update_attributes(time_zone: new_york_tz.name)
+    @inc_operation.process
+    @user.reload
+    assert @user.daily_score.present?
+    assert_equal(
+      @user.daily_score.expires_at.change(usec: 0),
+      new_york_tz.now.end_of_day.in_time_zone('UTC').change(usec: 0)
+    )
+  end
+
+  test 'sets weekly score expiration date '\
+      'to the end of the current week in America/New_York '\
+      'for a user in America/New_York' do
+    @user.update_attributes(time_zone: new_york_tz.name)
+    @inc_operation.process
+    @user.reload
+    assert @user.weekly_score.present?
+    assert_equal(
+      @user.weekly_score.expires_at.change(usec: 0),
+      new_york_tz.now.end_of_week.in_time_zone('UTC').change(usec: 0)
+    )
+  end
+
+  test 'sets monthly score expiration date '\
+      'to the end of the current month in America/New_York '\
+      'for a user in America/New_York' do
+    @user.update_attributes(time_zone: new_york_tz.name)
+    @inc_operation.process
+    @user.reload
+    assert @user.monthly_score.present?
+    assert_equal(
+      @user.monthly_score.expires_at.change(usec: 0),
+      new_york_tz.now.end_of_month.in_time_zone('UTC').change(usec: 0)
+    )
+  end
+
+  private
+
+  def new_york_tz
+    ActiveSupport::TimeZone['America/New_York']
+  end
 end


### PR DESCRIPTION
Properly use user timezone in leaderboards

Fix #258