### PR TITLE
Set time zone for API requests

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -2,6 +2,8 @@ module Api
   class BaseController < ActionController::Base
     protect_from_forgery with: :null_session
 
+    before_action :set_time_zone
+
     rescue_from(ActionController::ParameterMissing) do |err|
       render json: { missing_param: err.param }, status: :bad_request
     end
@@ -27,6 +29,17 @@ module Api
 
     def bad_request(reason)
       render status: :bad_request, json: { error: reason }
+    end
+
+    def set_time_zone
+      Time.zone = find_time_zone
+    end
+
+    def find_time_zone
+      request.headers['Time-Zone'] ||
+        params[:time_zone] ||
+        current_user.try(:time_zone) ||
+        Rails.configuration.time_zone
     end
   end
 end

--- a/test/functional/api/users_controller_test.rb
+++ b/test/functional/api/users_controller_test.rb
@@ -34,7 +34,7 @@ module Api
       assert_equal({ error: 'authentication failed' }.to_json, @response.body)
     end
 
-    test 'GET /show, given a headr authorization token, it should return current user' do
+    test 'GET /show, given a header authorization token, it should return current user' do
       @request.headers['Authorization'] = '123'
       get :show
       assert_response :success


### PR DESCRIPTION
API requests discarded user's time zone configuration. As a result some
calculations, such as the daily tomatoes counter, could display a wrong
value.

Example scenario: if a user in America/New_York creates a tomato at
18:59, that is 23:59 UTC in this period of the year, counters will be off
by one between 19:00 and 23:59 America/New_York, because it's a new day
in the UTC time zone, that is the default time zone used by the app.

API's `BaseController#set_time_zone` before filter method sets Rails time
zone according to the client's request or user's time zone configuration.

Time zone setting precedence is:

1. `Time-Zone` header value
2. `time_zone` parameter
3. user's time zone configuration
4. Rails default time zone

Closes https://github.com/tomatoes-app/tomatoes/issues/264.