### PR TITLE
Fix invalid time zone argument error

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -33,13 +33,15 @@ module Api
 
     def set_time_zone
       Time.zone = find_time_zone
+    rescue ArgumentError => e
+      logger.error "Argument error: #{e}"
+      Time.zone = Rails.configuration.time_zone
     end
 
     def find_time_zone
       request.headers['Time-Zone'] ||
         params[:time_zone] ||
-        current_user.try(:time_zone) ||
-        Rails.configuration.time_zone
+        current_user.try(:time_zone)
     end
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -20,14 +20,14 @@ class ApplicationController < ActionController::Base
 
   def set_time_zone
     Time.zone = find_time_zone
+  rescue ArgumentError => e
+    logger.error "Argument error: #{e}"
+    Time.zone = Rails.configuration.time_zone
   end
 
   def find_time_zone
-    if current_user.try(:time_zone).present?
-      current_user.time_zone
-    else
+    current_user.try(:time_zone) ||
       ActiveSupport::TimeZone[-cookies[:timezone].to_i.minutes]
-    end
   end
 
   def set_locale

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -176,6 +176,10 @@ class User
     image_value && !image_value.empty? ? image_value : User::DEFAULT_IMAGE_FILE
   end
 
+  def time_zone
+    self[:time_zone] if self[:time_zone].present?
+  end
+
   def currency_unit
     User::CURRENCIES[currency]
   end

--- a/test/functional/api/users_controller_test.rb
+++ b/test/functional/api/users_controller_test.rb
@@ -94,6 +94,14 @@ module Api
       end
     end
 
+    test 'GET /show, '\
+        'user time zone is invalid, '\
+        'it uses the default time zone' do
+      @user.update_attributes(time_zone: 'invalid')
+      get :show, token: '123'
+      assert_response :success
+    end
+
     test 'PATCH /update, given an invalid token, it should return an error' do
       patch :update, token: 'invalid_token', user: { name: 'Foo' }
       assert_response :unauthorized

--- a/test/functional/users_controller_test.rb
+++ b/test/functional/users_controller_test.rb
@@ -38,4 +38,12 @@ class UsersControllerTest < ActionController::TestCase
 
     assert_redirected_to root_path
   end
+
+  test 'GET /show, '\
+      'user time zone is invalid, '\
+      'it uses the default time zone' do
+    @user.update_attributes(time_zone: 'invalid')
+    get :show, id: @user.to_param
+    assert_response :success
+  end
 end

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -185,4 +185,12 @@ class UserTest < ActiveSupport::TestCase
 
     assert_equal User::DEFAULT_IMAGE_FILE, user.image_file
   end
+
+  test 'time_zone should return time_zone only if not blank' do
+    user = User.new(time_zone: '')
+    assert_nil user.time_zone
+
+    user.time_zone = 'timezone'
+    assert user.time_zone, 'timezone'
+  end
 end


### PR DESCRIPTION
If a user has an empty string set as a time zone, API requests will fail
with the error:

    An ArgumentError occurred in tomatoes#create:
      Invalid Timezone

This update fixes this issue and a more generic issue if the user has a
time zone that is an invalid time zone. Note: time zone attribute
validation is missing, maybe we should validate that values for that
attribute are included in the list of valid time zone names.