### PR TITLE
Fix no method error

### DIFF
--- a/app/controllers/api/projects_controller.rb
+++ b/app/controllers/api/projects_controller.rb
@@ -1,5 +1,7 @@
 module Api
   class ProjectsController < BaseController
+    include ProjectsParams
+
     before_action :authenticate_user!
     before_action :find_project, only: [:show, :update, :destroy]
 
@@ -48,10 +50,6 @@ module Api
 
     def find_project
       @project = current_user.projects.find(params[:id])
-    end
-
-    def resource_params
-      params.require(:project).permit(:name, :tag_list, :money_budget, :time_budget)
     end
   end
 end

--- a/app/controllers/api/tomatoes_controller.rb
+++ b/app/controllers/api/tomatoes_controller.rb
@@ -1,5 +1,7 @@
 module Api
   class TomatoesController < BaseController
+    include TomatoesParams
+
     before_action :authenticate_user!
     before_action :find_tomato, only: [:show, :update, :destroy]
 
@@ -57,10 +59,6 @@ module Api
 
     def find_tomato
       @tomato = current_user.tomatoes.find(params[:id])
-    end
-
-    def resource_params
-      params.require(:tomato).try(:permit, :tag_list)
     end
   end
 end

--- a/app/controllers/api/tomatoes_controller.rb
+++ b/app/controllers/api/tomatoes_controller.rb
@@ -60,7 +60,7 @@ module Api
     end
 
     def resource_params
-      params.require(:tomato).permit(:tag_list)
+      params.require(:tomato).try(:permit, :tag_list)
     end
   end
 end

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -1,5 +1,7 @@
 module Api
   class UsersController < BaseController
+    include UsersParams
+
     before_action :authenticate_user!
 
     # GET /api/user
@@ -14,23 +16,6 @@ module Api
       else
         render status: :unprocessable_entity, json: current_user.errors
       end
-    end
-
-    private
-
-    def resource_params
-      params.require(:user).permit(
-        :name,
-        :email,
-        :image,
-        :time_zone,
-        :color,
-        :work_hours_per_day,
-        :average_hourly_rate,
-        :currency,
-        :volume,
-        :ticking
-      )
     end
   end
 end

--- a/app/controllers/concerns/projects_params.rb
+++ b/app/controllers/concerns/projects_params.rb
@@ -1,11 +1,12 @@
 module ProjectsParams
   def resource_params
-    params.require(:project).try(
-      :permit,
-      :name,
-      :tag_list,
-      :money_budget,
-      :time_budget
-    )
+    params.permit(
+      project: [
+        :name,
+        :tag_list,
+        :money_budget,
+        :time_budget
+      ]
+    ).require(:project)
   end
 end

--- a/app/controllers/concerns/projects_params.rb
+++ b/app/controllers/concerns/projects_params.rb
@@ -1,0 +1,11 @@
+module ProjectsParams
+  def resource_params
+    params.require(:project).try(
+      :permit,
+      :name,
+      :tag_list,
+      :money_budget,
+      :time_budget
+    )
+  end
+end

--- a/app/controllers/concerns/tomatoes_params.rb
+++ b/app/controllers/concerns/tomatoes_params.rb
@@ -1,0 +1,5 @@
+module TomatoesParams
+  def resource_params
+    params.require(:tomato).try(:permit, :tag_list)
+  end
+end

--- a/app/controllers/concerns/tomatoes_params.rb
+++ b/app/controllers/concerns/tomatoes_params.rb
@@ -1,5 +1,5 @@
 module TomatoesParams
   def resource_params
-    params.require(:tomato).try(:permit, :tag_list)
+    params.permit(tomato: [:tag_list]).require(:tomato)
   end
 end

--- a/app/controllers/concerns/users_params.rb
+++ b/app/controllers/concerns/users_params.rb
@@ -1,17 +1,18 @@
 module UsersParams
   def resource_params
-    params.require(:user).try(
-      :permit,
-      :name,
-      :email,
-      :image,
-      :time_zone,
-      :color,
-      :work_hours_per_day,
-      :average_hourly_rate,
-      :currency,
-      :volume,
-      :ticking
-    )
+    params.permit(
+      user: [
+        :name,
+        :email,
+        :image,
+        :time_zone,
+        :color,
+        :work_hours_per_day,
+        :average_hourly_rate,
+        :currency,
+        :volume,
+        :ticking
+      ]
+    ).require(:user)
   end
 end

--- a/app/controllers/concerns/users_params.rb
+++ b/app/controllers/concerns/users_params.rb
@@ -1,0 +1,17 @@
+module UsersParams
+  def resource_params
+    params.require(:user).try(
+      :permit,
+      :name,
+      :email,
+      :image,
+      :time_zone,
+      :color,
+      :work_hours_per_day,
+      :average_hourly_rate,
+      :currency,
+      :volume,
+      :ticking
+    )
+  end
+end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -1,4 +1,6 @@
 class ProjectsController < ApplicationController
+  include ProjectsParams
+
   before_action :authenticate_user!
   before_action :find_project, only: [:show, :edit, :update, :destroy]
 
@@ -49,9 +51,5 @@ class ProjectsController < ApplicationController
 
   def find_project
     @project = current_user.projects.find(params[:id])
-  end
-
-  def resource_params
-    params.require(:project).permit(:name, :tag_list, :money_budget, :time_budget)
   end
 end

--- a/app/controllers/tomatoes_controller.rb
+++ b/app/controllers/tomatoes_controller.rb
@@ -1,4 +1,6 @@
 class TomatoesController < ApplicationController
+  include TomatoesParams
+
   before_action :authenticate_user!, except: [:by_day, :by_hour]
   before_action :find_user, only: [:by_day, :by_hour]
   before_action :find_tomato, only: [:show, :edit, :update, :destroy]
@@ -113,9 +115,5 @@ class TomatoesController < ApplicationController
     else
       I18n.t('tomato.short_break')
     end
-  end
-
-  def resource_params
-    params.require(:tomato).permit(:tag_list)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,6 @@
 class UsersController < ApplicationController
+  include UsersParams
+
   before_action :authenticate_user!, except: :show
   before_action :same_user!, except: :show
 
@@ -23,22 +25,5 @@ class UsersController < ApplicationController
   def destroy
     @user.destroy
     redirect_to root_url
-  end
-
-  private
-
-  def resource_params
-    params.require(:user).permit(
-      :name,
-      :email,
-      :image,
-      :time_zone,
-      :color,
-      :work_hours_per_day,
-      :average_hourly_rate,
-      :currency,
-      :volume,
-      :ticking
-    )
   end
 end

--- a/test/functional/api/tomatoes_controller_test.rb
+++ b/test/functional/api/tomatoes_controller_test.rb
@@ -141,6 +141,12 @@ module Api
       assert_match('tomato', parsed_response['missing_param'])
     end
 
+    test 'POST /create, with the wrong root param type, it should not return any error' do
+      # this request should fail because tomato is not a hash parameter
+      post :create, token: '123', tomato: 'tag_list'
+      assert_response :success
+    end
+
     test 'PATCH /update, given an invalid token, it should return an error' do
       patch :update, token: 'invalid_token', id: @tomato1.id, tomato: { tag_list: 'three' }
       assert_response :unauthorized

--- a/test/functional/api/tomatoes_controller_test.rb
+++ b/test/functional/api/tomatoes_controller_test.rb
@@ -141,10 +141,13 @@ module Api
       assert_match('tomato', parsed_response['missing_param'])
     end
 
-    test 'POST /create, with the wrong root param type, it should not return any error' do
+    test 'POST /create, with the wrong root param type, it should return a bad request error' do
       # this request should fail because tomato is not a hash parameter
       post :create, token: '123', tomato: 'tag_list'
-      assert_response :success
+      assert_response :bad_request
+      assert_equal 'application/json', @response.content_type
+      parsed_response = JSON.parse(@response.body)
+      assert_match('tomato', parsed_response['missing_param'])
     end
 
     test 'PATCH /update, given an invalid token, it should return an error' do

--- a/test/functional/tomatoes_controller_test.rb
+++ b/test/functional/tomatoes_controller_test.rb
@@ -31,10 +31,8 @@ class TomatoesControllerTest < ActionController::TestCase
   end
 
   test 'should create tomato' do
-    @tomato = @user.tomatoes.build(tag_list: 'one, two')
-
     assert_difference('Tomato.count') do
-      post :create, tomato: @tomato.attributes
+      post :create, tomato: { tag_list: '' }
     end
 
     assert_redirected_to root_path
@@ -51,7 +49,7 @@ class TomatoesControllerTest < ActionController::TestCase
   end
 
   test 'should update tomato' do
-    put :update, id: @tomato.to_param, tomato: @tomato.attributes
+    put :update, id: @tomato.to_param, tomato: { tag_list: '' }
     assert_redirected_to tomato_path(assigns(:tomato))
   end
 


### PR DESCRIPTION
If a POST request includes a `tomato` parameter that is not a hash,
Rails raises an exception because the value doesn't define `#permit`.

Fix the issue by *trying* to send the `#permit` message to the param
value.

Note: this isn't an optimal solution because malformed requests will
end up creating tomatoes, but it's better than returning a 500
response.