### PR TITLE
Update date time types

### DIFF
--- a/app/models/concerns/expiring.rb
+++ b/app/models/concerns/expiring.rb
@@ -1,7 +1,9 @@
 module Expiring
   extend ActiveSupport::Concern
+
   included do
     field :eat, as: :expires_at, type: Time
+
     index({ eat: 1 }, expire_after_seconds: 0, name: 'expiration_index')
   end
 end

--- a/app/models/concerns/score.rb
+++ b/app/models/concerns/score.rb
@@ -2,11 +2,20 @@ module Score
   extend ActiveSupport::Concern
 
   included do
+    include Mongoid::Timestamps
+
     belongs_to :user, foreign_key: :uid
 
     field :s, as: :score, type: Integer
-    field :cat, as: :created_at, type: DateTime
-    field :uat, as: :updated_at, type: DateTime
+
+    # Note: `Mongoid::Timestamps` module defines `created_at`, `updated_at`,
+    # and callbacks to keep these fields up to date. `::fields` is a hash table
+    # that contains document's fields. This is a similar approach used by
+    # `Mongoid::Timestamps::Short` to define short names for timestamp fields.
+    fields.delete('created_at')
+    field :cat, as: :created_at, type: Time
+    fields.delete('updated_at')
+    field :uat, as: :updated_at, type: Time
 
     index({ uid: 1 }, unique: true, name: 'uid_index')
     index({ s: -1 }, name: 'score_index')

--- a/app/models/concerns/score.rb
+++ b/app/models/concerns/score.rb
@@ -1,7 +1,9 @@
 module Score
   extend ActiveSupport::Concern
+
   included do
     belongs_to :user, foreign_key: :uid
+
     field :s, as: :score, type: Integer
     field :cat, as: :created_at, type: DateTime
     field :uat, as: :updated_at, type: DateTime


### PR DESCRIPTION
Let's use `Mongoid::Timestamps` to keep score documents timestamp fields up to date and update their type to use `Time`, that's the conventional type used by timestamp fields.