### PR TITLE
Choose duration for tomato

### DIFF
--- a/app/assets/javascripts/TT.js
+++ b/app/assets/javascripts/TT.js
@@ -142,7 +142,7 @@ var TT = function() {
     show([settings.formId]);
 
     $("#" + settings.formId + " input[type=text]").focus();
-    $("#tomato_duration").val(tomatoDuration * 60);
+    $("#tomato_duration").val(tomatoDuration);
   }
 
   var stateSignIn = function() {

--- a/app/assets/javascripts/TT.js
+++ b/app/assets/javascripts/TT.js
@@ -142,6 +142,7 @@ var TT = function() {
     show([settings.formId]);
 
     $("#" + settings.formId + " input[type=text]").focus();
+    $("#tomato_duration").val(tomatoDuration * 60);
   }
 
   var stateSignIn = function() {

--- a/app/assets/javascripts/TT_init.js
+++ b/app/assets/javascripts/TT_init.js
@@ -29,6 +29,7 @@ soundManager.setup({
 
 function startCallback(event) {
   if('idle' == TT.getStatus()) {
+    tomatoDuration = parseInt(document.getElementById("duration_time_input").value)/60;
     TT.start(tomatoDuration, currentUser ? TT.stateNewForm : TT.stateSignIn);
     event.preventDefault();
   }

--- a/app/assets/javascripts/TT_init.js
+++ b/app/assets/javascripts/TT_init.js
@@ -31,7 +31,6 @@ function startCallback(event) {
   if('idle' == TT.getStatus()) {
     chosenDuration = document.getElementById("duration_time_input").value;
     tomatoDuration = parseInt(chosenDuration);
-    if(DEBUG) tomatoDuration /= 60;
     TT.start(tomatoDuration, currentUser ? TT.stateNewForm : TT.stateSignIn);
     event.preventDefault();
   }

--- a/app/assets/javascripts/TT_init.js
+++ b/app/assets/javascripts/TT_init.js
@@ -31,6 +31,7 @@ function startCallback(event) {
   if('idle' == TT.getStatus()) {
     chosenDuration = document.getElementById("duration_time_input").value;
     tomatoDuration = parseInt(chosenDuration);
+    if(DEBUG) tomatoDuration /= 60;
     TT.start(tomatoDuration, currentUser ? TT.stateNewForm : TT.stateSignIn);
     event.preventDefault();
   }

--- a/app/assets/javascripts/TT_init.js
+++ b/app/assets/javascripts/TT_init.js
@@ -29,7 +29,8 @@ soundManager.setup({
 
 function startCallback(event) {
   if('idle' == TT.getStatus()) {
-    tomatoDuration = parseInt(document.getElementById("duration_time_input").value)/60;
+    chosenDuration = document.getElementById("duration_time_input").value;
+    tomatoDuration = parseInt(chosenDuration);
     TT.start(tomatoDuration, currentUser ? TT.stateNewForm : TT.stateSignIn);
     event.preventDefault();
   }

--- a/app/assets/stylesheets/welcome.scss
+++ b/app/assets/stylesheets/welcome.scss
@@ -5,3 +5,14 @@
 tr.highlight {
   background-color: $state-success-bg;
 }
+.choose_duration {
+  width: 25rem;
+  margin: 0 auto;
+}
+.choose_duration__input {
+  height: 7rem;
+}
+.choose_duration__output {
+  display: inline-block;
+}
+

--- a/app/controllers/concerns/tomatoes_params.rb
+++ b/app/controllers/concerns/tomatoes_params.rb
@@ -1,5 +1,5 @@
 module TomatoesParams
   def resource_params
-    params.permit(tomato: [:tag_list]).require(:tomato)
+    params.permit(tomato: [:tag_list, :duration]).require(:tomato)
   end
 end

--- a/app/helpers/tomatoes_helper.rb
+++ b/app/helpers/tomatoes_helper.rb
@@ -1,5 +1,5 @@
 module TomatoesHelper
   def tomato_duration(tomato)
-    "#{(tomato.created_at - Tomato::DURATION).strftime('%I:%M %p')} - #{tomato.created_at.strftime('%I:%M %p')}"
+    "#{(tomato.created_at - tomato.duration.to_i.minutes).strftime('%I:%M %p')} - #{tomato.created_at.strftime('%I:%M %p')}"
   end
 end

--- a/app/helpers/tomatoes_helper.rb
+++ b/app/helpers/tomatoes_helper.rb
@@ -1,5 +1,5 @@
 module TomatoesHelper
   def tomato_duration(tomato)
-    "#{(tomato.created_at - tomato.duration.to_i.minutes).strftime('%I:%M %p')} - #{tomato.created_at.strftime('%I:%M %p')}"
+    "#{(tomato.created_at - tomato.duration.minutes).strftime('%I:%M %p')} - #{tomato.created_at.strftime('%I:%M %p')}"
   end
 end

--- a/app/models/tomato.rb
+++ b/app/models/tomato.rb
@@ -21,7 +21,7 @@ class Tomato
   DURATION       = Rails.env.development? ? 25 : 25 * 60 # pomodoro default duration in seconds
   DURATION_MIN   = 25 # pomodoro default duration in minutes
   DURATION_MAX   = 60 # pomodoro default duration in minutes
-  BREAK_DURATION = Rails.env.development? ? 5  : 5 * 60  # pomodoro default break duration in seconds
+  BREAK_DURATION = Rails.env.development? ? 5 : 5 * 60 # pomodoro default break duration in seconds
 
   include ActionView::Helpers::TextHelper
   include ApplicationHelper

--- a/app/models/tomato.rb
+++ b/app/models/tomato.rb
@@ -11,6 +11,8 @@ class Tomato
 
   index(created_at: 1)
 
+  field :duration, type: String
+
   validate :must_not_overlap, on: :create
 
   after_create :increment_score

--- a/app/models/tomato.rb
+++ b/app/models/tomato.rb
@@ -11,7 +11,7 @@ class Tomato
 
   index(created_at: 1)
 
-  field :duration, type: String
+  field :duration, type: Integer
 
   validate :must_not_overlap, on: :create
 

--- a/app/models/tomato.rb
+++ b/app/models/tomato.rb
@@ -11,8 +11,6 @@ class Tomato
 
   index(created_at: 1)
 
-  field :duration, type: Integer
-
   validate :must_not_overlap, on: :create
 
   after_create :increment_score
@@ -22,6 +20,8 @@ class Tomato
   DURATION_MIN   = 25 # pomodoro default duration in minutes
   DURATION_MAX   = 60 # pomodoro default duration in minutes
   BREAK_DURATION = Rails.env.development? ? 5 : 5 * 60 # pomodoro default break duration in seconds
+
+  field :duration, type: Integer, default: DURATION_MIN
 
   include ActionView::Helpers::TextHelper
   include ApplicationHelper
@@ -68,9 +68,9 @@ class Tomato
   private
 
   def must_not_overlap
-    last_tomato = user.tomatoes.after(Time.zone.now - DURATION.seconds).order_by([[:created_at, :desc]]).first
+    last_tomato = user.tomatoes.after(Time.zone.now - duration.minutes).order_by([[:created_at, :desc]]).first
     return unless last_tomato
-    limit = (DURATION.seconds - (Time.zone.now - last_tomato.created_at)).seconds
+    limit = (duration.minutes - (Time.zone.now - last_tomato.created_at)).seconds
     errors.add(:base, I18n.t('errors.messages.must_not_overlap', limit: humanize(limit)))
   end
 

--- a/app/models/tomato.rb
+++ b/app/models/tomato.rb
@@ -19,6 +19,8 @@ class Tomato
   after_destroy :decrement_score
 
   DURATION       = Rails.env.development? ? 25 : 25 * 60 # pomodoro default duration in seconds
+  DURATION_MIN   = 25 # pomodoro default duration in minutes
+  DURATION_MAX   = 60 # pomodoro default duration in minutes
   BREAK_DURATION = Rails.env.development? ? 5  : 5 * 60  # pomodoro default break duration in seconds
 
   include ActionView::Helpers::TextHelper

--- a/app/views/tomatoes/_form.html.erb
+++ b/app/views/tomatoes/_form.html.erb
@@ -1,6 +1,7 @@
 <% remote = false if local_assigns[:remote].nil? %>
 
 <%= form_for(@tomato, remote: remote) do |f| %>
+  <%= f.hidden_field :duration %>
   <% if @tomato.errors.any? %>
     <div id="error_explanation">
       <h2><%= pluralize(@tomato.errors.count, "error") %> prohibited this tomato from being saved:</h2>

--- a/app/views/tomatoes/show.html.erb
+++ b/app/views/tomatoes/show.html.erb
@@ -2,7 +2,7 @@
 
 <dl class="dl-horizontal">
   <dt><%= t('mongoid.attributes.tomato.started_at') %></dt>
-  <dd><%= l(@tomato.created_at - Tomato::DURATION, format: :long) %></dd>
+  <dd><%= l(@tomato.created_at - @tomato.duration.minutes, format: :long) %></dd>
   <dt><%= t('tomato.duration') %></dt>
   <dd><%= tomato_duration(@tomato) %></dd>
   <dt><%= t('mongoid.attributes.tomato.tags') %></dt>

--- a/app/views/welcome/_tomatoes_timer.html.erb
+++ b/app/views/welcome/_tomatoes_timer.html.erb
@@ -65,4 +65,15 @@
 <div id="start_container" class="center-block">
   <%= link_to t('timer.start'), '#', id: 'start', class: 'btn btn-default btn-lg' %>
   <p id="start_hint" class="help-block"><%= t('timer.or_press_space') %></p>
+  <div class="form-group" style="width: 50%; margin: 0 auto;">
+    <input name="duration_time"
+           id="duration_time_input"
+           class="form-control"
+           type="range"
+           min="5"
+           max="60"
+           value="5"
+           oninput="duration_time_output.value = duration_time_input.value">
+    <output style="display: inline-block;" name="duration_time_output" id="duration_time_output">5</output>
+  </div>
 </div>

--- a/app/views/welcome/_tomatoes_timer.html.erb
+++ b/app/views/welcome/_tomatoes_timer.html.erb
@@ -65,15 +65,19 @@
 <div id="start_container" class="center-block">
   <%= link_to t('timer.start'), '#', id: 'start', class: 'btn btn-default btn-lg' %>
   <p id="start_hint" class="help-block"><%= t('timer.or_press_space') %></p>
-  <div class="form-group" style="width: 50%; margin: 0 auto;">
+  <div class="form-group choose_duration">
+    <label for="duration_time_input"><%= t('tomato.duration') %></label>
     <input name="duration_time"
            id="duration_time_input"
-           class="form-control"
+           class="form-control choose_duration__input"
            type="range"
            min="5"
            max="60"
            value="5"
            oninput="duration_time_output.value = duration_time_input.value">
-    <output style="display: inline-block;" name="duration_time_output" id="duration_time_output">5</output>
+    <output class="choose_duration__output" name="duration_time_output" id="duration_time_output">
+      5
+    </output>
+    <span><%= t('minutes') %></span>
   </div>
 </div>

--- a/app/views/welcome/_tomatoes_timer.html.erb
+++ b/app/views/welcome/_tomatoes_timer.html.erb
@@ -71,12 +71,12 @@
            id="duration_time_input"
            class="form-control choose_duration__input"
            type="range"
-           min="5"
-           max="60"
-           value="5"
+           min="<%= Tomato::DURATION_MIN %>"
+           max="<%= Tomato::DURATION_MAX %>"
+           value="<%= Tomato::DURATION_MIN %>"
            oninput="duration_time_output.value = duration_time_input.value">
     <output class="choose_duration__output" name="duration_time_output" id="duration_time_output">
-      5
+      <%= Tomato::DURATION_MIN %>
     </output>
     <span><%= t('minutes') %></span>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -119,6 +119,7 @@ en:
   overall_leaderboard: Overall leaderboard
   empty_leaderboard: No scores in this leaderboard
   leaderboards: Leaderboards
+  minutes: minutes
   daily: Daily
   weekly: Weekly
   monthly: Monthly

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -122,6 +122,7 @@ es:
   overall_leaderboard: Tabla de posiciones general
   empty_leaderboard: No existen registros en esta tabla de posiciones
   leaderboards: Tablas de posiciones
+  minutes: minutos
   daily: Diaria
   weekly: Semanal
   monthly: Mensual

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -117,6 +117,7 @@ fr:
   overall_leaderboard: Classement général
   empty_leaderboard: Il n'y a pas de données dans ce classement
   leaderboards: Classements
+  minutes: minutes
   daily: Aujourd'hui
   weekly: Cette semaine
   monthly: Ce mois-ci

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -115,6 +115,7 @@ pt-BR:
   overall_leaderboard: Placar de todo o tempo
   empty_leaderboard: Placar vazio
   leaderboards: Classificações
+  minutes: minutos
   daily: Diário
   weekly: Semanal
   monthly: Mensal

--- a/test/functional/tomatoes_controller_test.rb
+++ b/test/functional/tomatoes_controller_test.rb
@@ -9,7 +9,7 @@ class TomatoesControllerTest < ActionController::TestCase
       name: 'name',
       email: 'email@example.com'
     )
-    @tomato = @user.tomatoes.create(tag_list: 'one, two', created_at: Time.zone.now - 1.day)
+    @tomato = @user.tomatoes.create(tag_list: 'one, two', created_at: Time.zone.now - 1.day, duration: 25)
 
     @controller.stubs(:current_user).returns(@user)
   end

--- a/test/support/leaderboard_controller_test.rb
+++ b/test/support/leaderboard_controller_test.rb
@@ -12,7 +12,7 @@ module LeaderboardControllerTest
         name: 'name',
         email: 'email@example.com'
       )
-      @tomato = @user.tomatoes.create!(tag_list: 'one, two')
+      @tomato = @user.tomatoes.create!(tag_list: 'one, two', duration: 25)
     end
 
     test 'should get show' do

--- a/test/unit/helpers/tomatoes_helper_test.rb
+++ b/test/unit/helpers/tomatoes_helper_test.rb
@@ -3,8 +3,9 @@ require 'test_helper'
 class TomatoesHelperTest < ActionView::TestCase
   test 'tomato_duration should return a formatted string' do
     @created_at = Time.new(2011, 7, 24, 15, 10).in_time_zone
-    @ended_at = @created_at - Tomato::DURATION
-    @tomato = Tomato.new(created_at: @created_at)
+    duration = 5
+    @ended_at = @created_at - duration.minutes
+    @tomato = Tomato.new(created_at: @created_at, duration: duration)
 
     assert tomato_duration(@tomato) == "#{@ended_at.strftime('%I:%M %p')} - #{@created_at.strftime('%I:%M %p')}"
   end

--- a/test/unit/tomato_test.rb
+++ b/test/unit/tomato_test.rb
@@ -10,13 +10,13 @@ class TomatoTest < ActiveSupport::TestCase
 
   test 'must_not_overlap B' do
     user = User.create!
-    user.tomatoes.create!(created_at: Time.zone.now - Tomato::DURATION.seconds + 5.seconds)
+    user.tomatoes.create!(created_at: Time.zone.now - Tomato::DURATION_MIN.minutes + 5.seconds)
     assert !user.tomatoes.build.valid?
   end
 
   test 'must_not_overlap C' do
     user = User.create!
-    user.tomatoes.create!(created_at: Time.zone.now - Tomato::DURATION.seconds - 1.second)
+    user.tomatoes.create!(created_at: Time.zone.now - Tomato::DURATION_MIN.minutes - 1.second)
 
     assert user.tomatoes.build.valid?
   end


### PR DESCRIPTION
Idea naively implemented to choose the duration of tomato

![Home page](https://cloud.githubusercontent.com/assets/14128874/26086794/57be6670-39c3-11e7-9bc9-eb83b2e53078.png)
![Tomato page](https://cloud.githubusercontent.com/assets/14128874/26086839/9b83521c-39c3-11e7-93a8-bc8fd49c006e.png)


#### TODO

- [ ] Update API documentation to include the new `duration` param
- [ ] Update [`Api::Presenter::Tomato`](https://github.com/tomatoes-app/tomatoes/blob/master/app/models/api/presenter/tomato.rb) to include `duration`
- [ ] Update [`Tomato#must_not_overlap`](https://github.com/tomatoes-app/tomatoes/blob/master/app/models/tomato.rb#L66-L71) validation method to use instance's `duration`
- [x] Use `Tomato::DURATION` as the default duration value
- [ ] Update projects counters to take tomatoes duration into account
- [x] Update timer's duration output element to include a label, "Duration", and a unit of measurement, "minutes"