### PR TITLE
Fix routing error for tags#show

### DIFF
--- a/chrome_app/manifest.json
+++ b/chrome_app/manifest.json
@@ -1,1 +1,1 @@
-{"name":"Tomatoes","app":{"urls":["http://tomato.es/"],"launch":{"web_url":"http://tomato.es/"}},"icons":{"128":"icon_128.png"},"version":"0.14.7","description":"Pomodoro Technique\u00ae web-based time tracker"}
+{"name":"Tomatoes","app":{"urls":["http://tomato.es/"],"launch":{"web_url":"http://tomato.es/"}},"icons":{"128":"icon_128.png"},"version":"0.14.8","description":"Pomodoro Technique\u00ae web-based time tracker"}

--- a/config/application.rb
+++ b/config/application.rb
@@ -12,7 +12,7 @@ require 'bootstrap-social-rails'
 Bundler.require(*Rails.groups)
 
 module TomatoesApp
-  VERSION = '0.14.7'.freeze
+  VERSION = '0.14.8'.freeze
   REPO = 'https://github.com/tomatoes-app/tomatoes'.freeze
 
   class Application < Rails::Application

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,12 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :tags, only: [:index, :show]
+  resources :tags, only: :index
+  # Simulate a show action route for the tags resource. This action is more
+  # "permissive" than the default one. It allows tag ids to be strings that
+  # include any character, for instance it will match tag ids that include '/'
+  # or '.', that are special characters for the Rails router.
+  get '/tags/*id', to: 'tags#show', format: false, as: :tag
 
   resources :projects
 

--- a/test/functional/tags_controller_test.rb
+++ b/test/functional/tags_controller_test.rb
@@ -29,4 +29,13 @@ class TagsControllerTest < ActionController::TestCase
     assert_response :success
     assert response.body.include? @tag
   end
+
+  test 'should route tag with id that includes special characters' do
+    assert_routing(
+      '/tags/tag...',
+      controller: 'tags',
+      action: 'show',
+      id: 'tag...'
+    )
+  end
 end


### PR DESCRIPTION
Tag ids can include any character, but by default Rails' router
can't parse `.` characters as part of an id. This caused an error
that prevented some tags to be showed. This change includes a
regression test and a fix for this issue, that is a new routing
rule that uses a different pattern to match. See also:
http://guides.rubyonrails.org/routing.html#route-globbing-and-wildcard-segments