### PR TITLE
Dockerize project

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,10 +7,10 @@ If you find what looks like a bug:
 
 If you want to contribute an enhancement or a fix:
 
+1. Setup the project with [docker-compose](https://docs.docker.com/compose/) by running `docker-compose up`
 1. [Fork the project](https://help.github.com/articles/fork-a-repo) on github.
 1. [Create a topic branch](http://learn.github.com/p/branching.html).
 1. Make your changes with tests.
+1. You can run the test suite by launching `docker-compose exec web rake`
 1. Commit the changes without making changes to the Rakefile or any other files that aren’t related to your enhancement or fix.
 1. Send a pull request.
-
-See also [How to setup a development virtual server with Virtualbox](https://github.com/tomatoes-app/tomatoes#how-to-setup-a-development-virtual-server-with-virtualbox).

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM ruby:2.4.2
+
+ENV APP_HOME /tomatoes
+
+RUN mkdir $APP_HOME
+
+WORKDIR $APP_HOME
+
+ADD Gemfile* $APP_HOME/
+
+RUN bundle install
+
+ADD . $APP_HOME

--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -9,7 +9,7 @@ development:
       # Provides the hosts the default client can connect to. Must be an array
       # of host:port pairs. (required)
       hosts:
-        - localhost:27017
+        - <%= ENV["DO_HOST"] || 'localhost' %>:27017
       options:
         # Change the default write concern. (default = { w: 1 })
         # write:
@@ -135,7 +135,7 @@ test:
     default:
       database: tomatoes_app_test
       hosts:
-        - localhost:27017
+        - <%= ENV["DO_HOST"] || 'localhost' %>:27017
       options:
         read:
           mode: :primary

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '3'
+services:
+  mongo:
+    image: mongo
+    ports:
+    - 27017:27017
+
+  web:
+    build: .
+    volumes:
+      - .:/tomatoes
+    entrypoint: ./docker-entrypoint.sh 
+    ports:
+      - 3000:3000
+    depends_on:
+      - mongo
+    environment:
+      - DO_HOST=mongo

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Make sure databases exist, if not accessing will create them
+mongo --host mongo --eval "use tomatoes_app_development; use tomatoes_app_test; exit;"
+
+rails s


### PR DESCRIPTION
This commit adds Docker support with updated documentation on how to
contribute to the project.

This change is retro-compatible. You are not forced to run Docker and
you can keep working with your current setup. But if you prefer to use
containers or if you are a new contributor should help setting up the
project.

This should fix https://github.com/tomatoes-app/tomatoes/issues/218 and fix https://github.com/tomatoes-app/tomatoes/issues/128