### PR TITLE
Squash integration

### DIFF
--- a/.squash.yml
+++ b/.squash.yml
@@ -1,0 +1,3 @@
+deployments:
+  default:
+    port_forwarding: 3000:3000


### PR DESCRIPTION
This is a patch to integrate Squash.io with Tomatoes. I believe this is going to be handy to the project so any project maintainers and developers can quickly check the branch changes deployed on its own isolated VM.

Example of Tomatoes working with Squash: https://squash-setup-nlt7x.squash.io/

Squash is free for Open Source, maintainers just need to [signup ](https://squash.io/signup/) and reach out to the support through the chat window and we will enable a forever free Open Source account. Once this is done, Squash will post a comment on each Pull Request like this:

![squash-pr-comment](https://user-images.githubusercontent.com/98694/50752537-de98b200-120b-11e9-9d8f-264eddc4ca3f.png)

When you click on the Squash link in a new PR it will deploy the branch of code into a brand new VM, **this process takes about 2 minutes**.  

Let me know what you think please. Thanks.
