### PR TITLE
Pin mongo image 4.2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   mongo:
-    image: mongo
+    image: mongo:4.2
     ports:
     - 27017:27017
 


### PR DESCRIPTION
![image](https://github.com/tomatoes-app/tomatoes/assets/11408441/f334b79e-1373-437e-bd91-ed055d864372)
After filling in github oauth info, signins fail. Apparently the `OP_QUERY` opcode [was removed](https://www.mongodb.com/docs/v6.0/release-notes/6.0-compatibility/#legacy-opcodes-removed) in newer mongo images. The proper fix would be to update the client. Since I don't know how to use anything in this stack and I'm just running an instance for personal use, it is easier to pin a mongo docker image from when the project was maintained. So here is a note for any fellow travelers.